### PR TITLE
Fix info box text wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 stylesheets/variables.css
 npm-debug.log
 git-history*
+.idea/
+package-lock.json

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -84,6 +84,14 @@ body .header {
   /* Modal Content/Box */
 }
 
+/*
+ Modal Text Box
+ */
+.modal-content {
+  /* Make file-path text wrap, rather than disappear */
+  word-wrap: break-word;
+}
+
 body .navbar {
   margin-bottom: 0px;
   font-size: 20px;


### PR DESCRIPTION
Closes issue #5 
Long, unknown filepaths will now wrap within the modal text box when the user attempts to add a local repository.

**Changes**
- Added a modal-content section to the styles.css, with the appropriate behaviour
- Added minor ignores to the gitignore