### PR TITLE
Show diff panel at the appropriate times only

### DIFF
--- a/app/misc/git.js
+++ b/app/misc/git.js
@@ -1,4 +1,5 @@
 "use strict";
+exports.__esModule = true;
 var opn = require('opn');
 var $ = require("jquery");
 var Git = require("nodegit");
@@ -58,9 +59,10 @@ function addAndCommit() {
             sign = Git.Signature.now(username, password);
         }
         else {
-            sign = Git.Signature.default(repository);
+            sign = Git.Signature["default"](repository);
         }
         commitMessage = document.getElementById('commit-message-input').value;
+        //console.log(sign.toString());
         if (readFile.exists(repoFullPath + "/.git/MERGE_HEAD")) {
             var tid = readFile.read(repoFullPath + "/.git/MERGE_HEAD", null);
             console.log("theirComit: " + tid);
@@ -74,6 +76,7 @@ function addAndCommit() {
     })
         .then(function (oid) {
         theirCommit = null;
+        //console.log("8.0");
         console.log("Commit successful: " + oid.tostrS());
         hideDiffPanel();
         clearModifiedFilesList();
@@ -89,6 +92,7 @@ function addAndCommit() {
         updateModalText("Oops, error occours! If u haven't login, please login and try again.");
     });
 }
+// Clear all modified files from the left file panel
 function clearModifiedFilesList() {
     var filePanel = document.getElementById("files-changed");
     while (filePanel.firstChild) {
@@ -107,6 +111,19 @@ function clearSelectAllCheckbox() {
     document.getElementById('select-all-checkbox').checked = false;
 }
 function getAllCommits(callback) {
+    // Git.Repository.open(repoFullPath)
+    // .then(function(repo) {
+    //   return repo.getHeadCommit();
+    // })
+    // .then(function(firstCommitOnMaster){
+    //   let history = firstCommitOnMaster.history(Git.Revwalk.SORT.Time);
+    //
+    //   history.on("end", function(commits) {
+    //     callback(commits);
+    //   });
+    //
+    //   history.start();
+    // });
     var repos;
     var allCommits = [];
     var aclist = [];
@@ -188,7 +205,7 @@ function pullFromRemote() {
         .then(function (annotated) {
         console.log("4.0  " + annotated);
         Git.Merge.merge(repository, annotated, null, {
-            checkoutStrategy: Git.Checkout.STRATEGY.FORCE,
+            checkoutStrategy: Git.Checkout.STRATEGY.FORCE
         });
         theirCommit = annotated;
     })
@@ -202,6 +219,9 @@ function pullFromRemote() {
             refreshAll(repository);
         }
     });
+    //   .then(function(updatedRepository) {
+    //     refreshAll(updatedRepository);
+    // });
 }
 function pushToRemote() {
     var branch = document.getElementById("branch-name").innerText;
@@ -236,6 +256,7 @@ function createBranch() {
     console.log(branchName + "!!!!!!");
     Git.Repository.open(repoFullPath)
         .then(function (repo) {
+        // Create a new branch on head
         repos = repo;
         addCommand("git branch " + branchName);
         return repo.getHeadCommit()
@@ -290,6 +311,7 @@ function mergeCommits(from) {
     Git.Repository.open(repoFullPath)
         .then(function (repo) {
         repos = repo;
+        //return repos.getCommit(fromSha);
         addCommand("git merge " + from);
         return Git.Reference.nameToId(repos, 'refs/heads/' + from);
     })
@@ -300,7 +322,7 @@ function mergeCommits(from) {
         .then(function (annotated) {
         console.log("4.0  " + annotated);
         Git.Merge.merge(repos, annotated, null, {
-            checkoutStrategy: Git.Checkout.STRATEGY.FORCE,
+            checkoutStrategy: Git.Checkout.STRATEGY.FORCE
         });
         theirCommit = annotated;
     })
@@ -322,6 +344,7 @@ function rebaseCommits(from, to) {
     Git.Repository.open(repoFullPath)
         .then(function (repo) {
         repos = repo;
+        //return repos.getCommit(fromSha);
         addCommand("git rebase " + to);
         return Git.Reference.nameToId(repos, 'refs/heads/' + from);
     })
@@ -442,7 +465,9 @@ function displayModifiedFiles() {
                 }
             }
             modifiedFiles.forEach(displayModifiedFile);
+            // Add modified file to array of modified files 'modifiedFiles'
             function addModifiedFile(file) {
+                // Check if modified file is already being displayed
                 var filePaths = document.getElementsByClassName('file-path');
                 for (var i = 0; i < filePaths.length; i++) {
                     if (filePaths[i].innerHTML === file.path()) {
@@ -456,6 +481,7 @@ function displayModifiedFiles() {
                     fileModification: modification
                 });
             }
+            // Find HOW the file has been modified
             function calculateModification(status) {
                 if (status.isNew()) {
                     return "NEW";
@@ -476,11 +502,13 @@ function displayModifiedFiles() {
                     return "IGNORED";
                 }
             }
+            // Add the modified file to the left file panel
             function displayModifiedFile(file) {
                 var filePath = document.createElement("p");
                 filePath.className = "file-path";
                 filePath.innerHTML = file.filePath;
                 var fileElement = document.createElement("div");
+                // Set how the file has been modified
                 if (file.fileModification === "NEW") {
                     fileElement.className = "file file-created";
                 }
@@ -499,7 +527,10 @@ function displayModifiedFiles() {
                 checkbox.className = "checkbox";
                 fileElement.appendChild(checkbox);
                 document.getElementById("files-changed").appendChild(fileElement);
-                fileElement.onclick = function () {
+                fileElement.onclick = function (e) {
+                    if (e.target !== this) {
+                        return;
+                    }
                     var doc = document.getElementById("diff-panel");
                     console.log(doc.style.width + 'oooooo');
                     if (doc.style.width === '0px' || doc.style.width === '') {

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -568,7 +568,10 @@ function displayModifiedFiles() {
 
         document.getElementById("files-changed").appendChild(fileElement);
 
-        fileElement.onclick = function() {
+        fileElement.onclick = function(e) {
+          if (e.target !== this) {
+            return;
+          }
           let doc = document.getElementById("diff-panel");
           console.log(doc.style.width + 'oooooo');
           if (doc.style.width === '0px' || doc.style.width === '') {


### PR DESCRIPTION
Closes #15.

Before, when you click on anywhere on a modified file, the diff panel pops up. This is unnecessary when the user just wants to select the checkboxes to select the files.

With these changes, when the user clicks on the checkbox of the file (in the bottom left corner), the diff panel does not pop up.

Changes made:
- when the modified file's HTML element is clicked, check if the target of the click is the checkbox. If it is the checkbox, then exit the function so that you don't execute the logic related to displaying the diff panel. 