### PR TITLE
Issue #12 clickable scripts to run Visual Git for Win Linux and Mac

### DIFF
--- a/run-bash-mac.command
+++ b/run-bash-mac.command
@@ -1,0 +1,5 @@
+#!/bin/bash  
+echo "Starting up VisualGit"
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd "${DIR}"
+npm start

--- a/run-bash.sh
+++ b/run-bash.sh
@@ -1,0 +1,19 @@
+#!/bin/bash  
+<<<<<<< HEAD
+<<<<<<< HEAD
+echo "Starting up VisualGit"  
+npm start
+=======
+cd "$(dirname "$0")"
+echo $PWD
+echo "Starting up VisualGit"  
+npm start
+$SHELL
+>>>>>>> d2b094f... Created two scripts one bash for ubuntu and mac and one batch for windows.
+=======
+cd "$(dirname "$0")"
+echo $PWD
+echo "Starting up VisualGit"  
+npm start
+$SHELL
+>>>>>>> eb5aebf... Created a desktop file to run the run bash script for ubuntu, need to create file for mac now

--- a/run-batch.bat
+++ b/run-batch.bat
@@ -1,0 +1,2 @@
+ECHO Running VisualGit
+npm start

--- a/run.desktop
+++ b/run.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Version=1.0
+Name=Visual Git
+Comment=Starts Visual Git
+Exec=bash -c '"$(dirname "$1")"/run-bash.sh' run-bash %k
+Terminal=true
+Type=Application


### PR DESCRIPTION
run.desktop runs the "npm start" command on ubuntu machines and will show up as a Visual Git executable

run-bash-mac.command runs the "npm start" command on mac machines

run-batch.bat runs the "npm start" command in the windows cmd

The user may need to run these commands once:
"chmod u+x run-bash.sh" on ubuntu or
"chmod +x run-bash-mac.command" on mac
OR on windows: 
run "run-batch.bat" as admin depending on user privileges

closes issue #12