### PR TITLE
Closes Issue#130, can now log in using either email or username at both locations.

### DIFF
--- a/app/components/authenticate.component.ts
+++ b/app/components/authenticate.component.ts
@@ -27,7 +27,7 @@ import { Component } from "@angular/core";
     </label>
     <br><br>
     <div class="input-group" style="width:280px;">
-      <input id="username" type="text" class="form-control" placeholder="username" aria-describedby="basic-addon1">
+      <input id="username" type="text" class="form-control" placeholder="Username or Email" aria-describedby="basic-addon1">
     </div>
     <br>
 

--- a/app/components/header.component.ts
+++ b/app/components/header.component.ts
@@ -56,7 +56,7 @@ import { GraphService } from "../services/graph.service";
             <form class="navbar-form navbar-right form-inline" role="form">
               <div class="form-group">
                 <label class="sr-only" for="Email">User name</label>
-                <input type="text" class="form-control" id="Email1" placeholder="Email" autofocus required />
+                <input type="text" class="form-control" id="Email1" placeholder="Username or Email" autofocus required style="width: 206px !important"/>
               </div>
               <div class="form-group">
                 <label class="sr-only" for="Password">Password</label>


### PR DESCRIPTION
Closes issue #130.

Changes made to the App include changing the placeholder text in the username section of both the main login screen and the inline login screen in the top right of the app. the functionality of the app allowed for users to use either their GitHub username or associated email address to log in. Now both log in places' reflect this functionality, with the placeholder text stating "Username or Email" at both places. Also, the username input area for the inline login screen has been made wider, to more comfortably accommodate email addresses, if the user wishes to use one.

files changed:

    app/components/header.component.ts
    app/components/authenticate.component.ts
